### PR TITLE
fixed a bug in _unpack_bytes()

### DIFF
--- a/mp3_tagger/id3.py
+++ b/mp3_tagger/id3.py
@@ -182,7 +182,9 @@ class ID3TagV2(ID3Tag):
                 if re.match(r'\w+', val):
                     pass
                 else:
-                    val = int(re.search(r'\d+', val).group(0))
+                    search_match = re.search(r'\d+', val)
+                    if search_match:
+                        val = int(search_match.group(0))
         return val
 
 # Versions for filter tags.


### PR DESCRIPTION
This function sometimes crashed when attempting to read strange data. The pattern would not match so there would be no group(0) - and it crashed instead of just returning `None`.